### PR TITLE
use public git address

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ mailer from Cockpit is used, so there is no additional configuration needed.
 
 ```
 cd path/to/cockpit/modules/addons
-git clone git@github.com:florianletsch/cockpit-mailqueue.git Mailqueue
+git clone https://github.com/florianletsch/cockpit-mailqueue.git Mailqueue
 ```
 
 1. Download or clone


### PR DESCRIPTION
To avoid:

```
Cloning into 'Mailqueue'...
The authenticity of host 'github.com (192.30.252.128)' can't be established.
RSA key fingerprint is 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)? y
Please type 'yes' or 'no': yes
Warning: Permanently added 'github.com,192.30.252.128' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.
```
